### PR TITLE
only show the nock insert when the base is selected

### DIFF
--- a/scad/fletching_jig.scad
+++ b/scad/fletching_jig.scad
@@ -308,5 +308,6 @@ module jig (    part_select = 0,
         base_mold(a = w - lid_lip, radius = r - lid_lip, height = h);
     }
     // nocking point
+    if (part_select == 1 || part_select == 0)
     nock_insert(nock, nock_width, nock_depth, arrow_diameter, arrow_offset);
 }


### PR DESCRIPTION
this hides the nock insert when selecting something other than the base (otherwise we get it printed in the middle of the arm, for instance)

also, I'm wondering if the vane offset shouldn't be from the bottom of the nock (because we care about the distance from the string, and nocks vary in length / shape)