### PR TITLE
Add option to specify outer width of the nock

### DIFF
--- a/scad/fletching_jig.scad
+++ b/scad/fletching_jig.scad
@@ -121,6 +121,7 @@ module jig (    part_select = 0,
                 nock = false,
                 nock_width = 3,
                 nock_depth = 3,
+                nock_diameter = 6,
                 base_style = "hexagon",
                 hinge_style = "ball joint",
                 fn = 30
@@ -212,6 +213,7 @@ module jig (    part_select = 0,
     error_treshold ("arm_gap", "max", abs(arm_gap), max_arm_gap);
     error_treshold ("nock_depth", "max", nock_depth, base_height - arrow_offset);
     error_treshold ("nock_width", "max", nock_width, arrow_diameter);
+    error_treshold ("nock_diameter", "min", nock_diameter, arrow_diameter);
 
     assert (min_hinge_width <= max_hinge_width && min_hinge_thickness <= max_hinge_thickness,
             "INVALID HINGE PARAMETERS"
@@ -223,8 +225,11 @@ module jig (    part_select = 0,
     {
         difference()
         {
-        base_mold(a = arm_width, radius = base_radius, height = base_height, hulled=hulled_base);
-            translate([0,0,arrow_offset]) cylinder_holer(height = base_height,radius = arrow_diameter/2,fn = fn);
+            base_mold(a = arm_width, radius = base_radius, height = base_height, hulled=hulled_base);
+            if (nock)
+                translate([0,0,arrow_offset]) cylinder_holer(height = base_height,radius = nock_diameter/2,fn = fn);
+            else
+                translate([0,0,arrow_offset]) cylinder_holer(height = base_height,radius = arrow_diameter/2,fn = fn);
             //hinge holer
             for (i = [0:2]) 
             {
@@ -234,7 +239,7 @@ module jig (    part_select = 0,
             }
         }
         if (nock == true)
-            nock_insert(nock_width, nock_depth, arrow_diameter, arrow_offset);
+            nock_insert(nock_width, nock_depth, nock_diameter, arrow_offset);
     }
 
     //arm

--- a/scad/main.scad
+++ b/scad/main.scad
@@ -54,6 +54,9 @@ nock_width = 3;//[1:0.1:5]
 // Depth of the nock (height of the nock guide)
 nock_depth = 4;//[1:0.1:10]
 
+// Outer width of the nock
+nock_diameter = 6;//[2:0.1:30]
+
 /* [Fletching] */
 
 // Length of the vane.
@@ -112,6 +115,7 @@ jig (
         nock,
         nock_width,
         nock_depth,
+        nock_diameter,
         base_style,
         hinge_style
     );


### PR DESCRIPTION
Hi!
The nocks on my arrows is slightly bigger than the arrow itself. I added a option to specify the outer nock width. This will modify the cutout from the base.  
In case the nock option is turned off, the arrow diameter is used like before.